### PR TITLE
log_comparison graph added to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,7 @@ Testbed: MacBook Pro (mid 2014)
   - 2.2GHz Intel Core i7
   - 16 GB 1600 MHz DDR3
 
+![log_cmp](https://cloud.githubusercontent.com/assets/4334970/17611401/e3d47084-6014-11e6-918d-535728ecea78.png)
+
+
 If you have any questions about the package or if you find a bug please write Song at ee08b397@gmail.com or Adam at adam.kelleher@buzzfeed.com or Andrew at andrew.kelleher@buzzfeed.com. 


### PR DESCRIPTION
Thinking about this comparison shows "close to linear time" well. 

```
import matplotlib.pyplot as plt
import math

log_num_nodes = range(1, 7)
cost = [0.000465893745422, 0.0039183139801, 0.0426687955856, 0.47996442318, 5.2688544035, 55.304875803]
log_cost = [math.log(c, 10) for c in cost]

linear_log = [log_cost[0] + power for power in range(len(cost))]

plt.figure()
plt.plot(log_num_nodes, log_cost, label = "logarithmic cost", linewidth = 1.5)
plt.plot(log_num_nodes, linear_log, label = "linear")
plt.plot(log_num_nodes, [math.log(60, 10)] * len(cost), label = "1 min")

plt.title("Performance vs linear time")
plt.legend(loc = "best").draggable()
plt.xlabel("Logarithmic number of nodes")
plt.ylabel("Logarithmic time (seconds)")

plt.show()
```
