### PR TITLE
add Python 3 support

### DIFF
--- a/h3/tree.py
+++ b/h3/tree.py
@@ -47,7 +47,7 @@ class Tree(object):
 
         edges = None # Release that memory.
 
-        for id, node in self.nodes.iteritems():
+        for id, node in self.nodes.items():
             if node.parent is None:
                 self.root = node
                 break
@@ -88,7 +88,7 @@ class Tree(object):
 
         :returns: A generator of all the leaf nodes in the Tree
         """
-        for node_id, node in self.nodes.iteritems():
+        for node_id, node in self.nodes.items():
             if not node.children:
                 yield node.node_id
 
@@ -227,7 +227,7 @@ class Tree(object):
                                    for child in self.nodes[node_id].children]
                 child_size_pair.sort(key=itemgetter(1), reverse=True)
                 if child_size_pair:
-                    self.nodes[node_id].children = list(zip(*child_size_pair)[0])
+                    self.nodes[node_id].children = list(zip(*child_size_pair))[0]
             depth += 1
             current_generation = next_generation
 
@@ -252,7 +252,7 @@ class Tree(object):
                                    for child in self.nodes[node_id].children]
                 child_size_pair.sort(key=itemgetter(1), reverse=True)
                 if child_size_pair:
-                    self.nodes[node_id].children = list(zip(*child_size_pair)[0])
+                    self.nodes[node_id].children = list(zip(*child_size_pair))[0]
             depth += 1
             current_generation = next_generation
 


### PR DESCRIPTION
That PR brings a couple of fixes in order to use the h3 layout with Python 3 (while maintaining Python 2 support of course).

FYI, I am a maintainer of the Tulip graph visualization framework (http://tulip.labri.fr). I have
created a Python plugin in order to use the h3 layout with Tulip. It will be available with the next Tulip
release (5.1).